### PR TITLE
Fix regexp for IE 9

### DIFF
--- a/ansi_up.js
+++ b/ansi_up.js
@@ -90,7 +90,7 @@
 
       // Do proper handling of sequences (aka - injest vi split(';') into state machine
       //match,codes,txt = text.match(/([\d;]+)m(.*)/m);
-      var matches = text.match(/([\d;]*)m([^\0]*)/m);
+      var matches = text.match(/([\d;]*)m([\s\S]*)/m);
 
       if (!matches) return text;
 


### PR DESCRIPTION
IE 9 (and maybe others) return html without any content within the span tags if [^] is used in the regexp.

You can verify by running your tests with [mochify](https://github.com/mantoni/mochify.js) (requires a free [SauceLabs](https://saucelabs.com/selenium/) account):

```
$ npm install mochify
```

Create a `.min-wd` file with this content:

```
{
  "sauceLabs": true,
  "browsers": [{
    "name": "chrome"
  }, {
    "name": "firefox"
  }, {
    "name": "internet explorer",
    "version": "9",
    "url": "http://maxantoni.de/doctype.html"
  }]
}
```

_Note: the "url" specified for IE is an empty web page that fixes the browser mode in a Selenium environment_

Then run

```
$ node_modules/.bin/mochify --wd
```

Pretty much every tests case fails in IE. Apply this patch and they are all green again.
