### PR TITLE
support bold colors

### DIFF
--- a/ansi_up.js
+++ b/ansi_up.js
@@ -114,8 +114,12 @@
           self.bright = 1;
         } else if ((num >= 30) && (num < 38)) {
           self.fg = ANSI_COLORS[self.bright][(num % 10)][key];
+        } else if ((num >= 90) && (num < 98)) {
+          self.fg = ANSI_COLORS[1][(num % 10)][key];
         } else if ((num >= 40) && (num < 48)) {
           self.bg = ANSI_COLORS[0][(num % 10)][key];
+        } else if ((num >= 100) && (num < 108)) {
+          self.bg = ANSI_COLORS[1][(num % 10)][key];
         }
       });
 

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -188,6 +188,17 @@ describe('ansi_up', function() {
         l.should.eql(expected);
       });
 
+      it('should transform a bold-foreground to html', function() {
+        this.timeout(1);
+        var fg = 92;
+        var start = "\033[" + fg + "m " + fg + " \033[0m";
+
+        var expected = "<span style=\"color:rgb(0, 255, 0)\"> " + fg + " </span>";
+
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql(expected);
+      });
+
       it('should transform a bold attr;background;foreground to html', function() {
         this.timeout(1);
         var attr = 1;
@@ -200,6 +211,19 @@ describe('ansi_up', function() {
         var l = ansi_up.ansi_to_html(start);
         l.should.eql(expected);
       });
+
+      it('should transform a bold-background;foreground to html', function() {
+        this.timeout(1);
+        var fg = 33;
+        var bg = 102;
+        var start = "\033[" + bg + ";" + fg + "m " + bg + ";" + fg + " \033[0m";
+
+        var expected = "<span style=\"color:rgb(187, 187, 0);background-color:rgb(0, 255, 0)\"> " + bg + ";" + fg + " </span>";
+
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql(expected);
+      });
+
 
       it('should transform a complex multi-line sequence to html', function() {
         this.timeout(1);


### PR DESCRIPTION
I wanted to colorize terminal output (linux, using TERM=ansi, docker) that was using these codes. Wikipedia lists them as

90–97 Set foreground text color, high intensity   aixterm (not in standard)
100–107   Set background color, high intensity    aixterm (not in standard)

(http://en.wikipedia.org/wiki/ANSI_escape_code)
