### PR TITLE
Add support for custom patterns

### DIFF
--- a/ansi_up.js
+++ b/ansi_up.js
@@ -57,7 +57,11 @@
 
     Ansi_Up.prototype.ansi_to_html = function (txt, options) {
 
-      var data4 = txt.split(/\033\[/);
+      options = typeof options == 'undefined' ? {} : options;
+      var use_pattern = typeof options.pattern != 'undefined' && options.pattern;
+      var pattern = use_pattern ? options.pattern : /\033\[/;
+
+      var data4 = txt.split(pattern);
 
       var first = data4.shift(); // the first chunk is not the result of the split
 


### PR DESCRIPTION
I had a different escape pattern to work with and thought I might contribute this functionality back.

Usage looks like:

``` js
ansi_up.ansi_to_html(element, 
  {
    use_classes: true,
    pattern: /\^\[/
  })
```
