### PR TITLE
Make ansi_up available on bower.io

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "ansi_up",
+  "main": "ansi_up.js",
+  "version": "1.1.2",
+  "homepage": "https://github.com/drudru/ansi_up",
+  "authors": [
+    "drudru <drudru@gmail.com>"
+  ],
+  "description": "Convert ansi sequences in strings to colorful HTML",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "ansi",
+    "html"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hi,
would be cool, to get ansi_up via `bower install ansi_up`. I already registered it, so you just need to keep that file in your repository and bump the version number once you change something.
Thanks!
