### PR TITLE
Handle cases where input may not be ANSI colored.

### DIFF
--- a/ansi_up.js
+++ b/ansi_up.js
@@ -56,7 +56,6 @@
     };
 
     Ansi_Up.prototype.ansi_to_html = function (txt, options) {
-
       var data4 = txt.split(/\033\[/);
 
       var first = data4.shift(); // the first chunk is not the result of the split
@@ -75,8 +74,12 @@
         a.push(b);
         return a;
       }, []);
-
-      var escaped_data = flattened_data.join('');
+      
+      if (typeof flattened_data == 'string') {
+        var escaped_data = first;
+      } else {
+        var escaped_data = flattened_data.join('');
+      }
 
       return escaped_data;
     };


### PR DESCRIPTION
Hit a case where we were receiving text that MAY or MAY NOT be ANSII colored. 

When the text was not colored, ansi_up would throw an exception:

```
Uncaught TypeError: flattened_data.join is not a functionAnsi_Up.ansi_to_html @ VM1590:80ansi_up.ansi_to_html @ VM1590:168(anonymous function) @ VM1591:2InjectedScript._evaluateOn @ VM1547:883InjectedScript._evaluateAndWrap @ VM1547:816InjectedScript.evaluate @ VM1547:682
```

This fixes that exception and returns the text if it isn't colored.