### PR TITLE
fix wrong matching (unsupported CSI and extraordinary text present)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,6 +87,7 @@ Thanks goes to the following contributors for their patches:
 - James R. White (<https://github.com/jamesrwhite>)
 - Aaron Stone (<https://github.com/sodabrew>)
 - Maximilian Antoni (<https://github.com/mantoni>)
+- AIZAWA Hina (<https://github.com/fetus-hina>)
 
 
 ## License

--- a/ansi_up.js
+++ b/ansi_up.js
@@ -90,17 +90,29 @@
 
       // Each 'chunk' is the text after the CSI (ESC + '[') and before the next CSI/EOF.
       //
-      // This regex matches two groups within a chunk.
-      // The first group matches all of the number+semicolon command sequences
-      // before the 'm' character. These are the graphics or SGR commands.
-      // The second group is the text (including newlines) that is colored by
-      // the first group's commands.
-      var matches = text.match(/^([\d;]*)m([\s\S]*)/m);
+      // This regex matches four groups within a chunk.
+      //
+      // The first and third groups match code type.
+      // We supported only SGR command. It has empty first group and 'm' in third.
+      //
+      // The second group matches all of the number+semicolon command sequences
+      // before the 'm' (or other trailing) character.
+      // These are the graphics or SGR commands.
+      //
+      // The last group is the text (including newlines) that is colored by
+      // the other group's commands.
+      var matches = text.match(/^([!\x3c-\x3f]*)([\d;]*)([\x20-\x2c]*[\x40-\x7e])([\s\S]*)/m);
 
       if (!matches) return text;
 
-      var orig_txt = matches[2];
-      var nums = matches[1].split(';');
+      var orig_txt = matches[4];
+      var nums = matches[2].split(';');
+
+      // We currently support only "SGR" (Select Graphic Rendition)
+      // Simply ignore if not a SGR command.
+      if (matches[1] !== '' || matches[3] !== 'm') {
+        return orig_txt;
+      }
 
       var self = this;
       nums.map(function (num_str) {

--- a/ansi_up.js
+++ b/ansi_up.js
@@ -95,7 +95,7 @@
       // before the 'm' character. These are the graphics or SGR commands.
       // The second group is the text (including newlines) that is colored by
       // the first group's commands.
-      var matches = text.match(/([\d;]*)m([\s\S]*)/m);
+      var matches = text.match(/^([\d;]*)m([\s\S]*)/m);
 
       if (!matches) return text;
 

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -303,7 +303,19 @@ describe('ansi_up', function() {
         l.should.eql(expected);
       });
     });
+    it('should correctly convert a string similar to CSI', function() {
+      // https://github.com/drudru/ansi_up/pull/15
+      this.timeout(1);
+      // "[1;31m" is a plain text. not an escape sequence.
+      var start = "foo\033[1@bar[1;31mbaz\033[0m";
+      var l = ansi_up.ansi_to_html(start);
 
+      // is all plain texts exist?
+      l.should.containEql('foo');
+      l.should.containEql('bar');
+      l.should.containEql('baz');
+      l.should.containEql('1;31m');
+    });
   });
 });
 

--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -316,6 +316,45 @@ describe('ansi_up', function() {
       l.should.containEql('baz');
       l.should.containEql('1;31m');
     });
+    describe('ignore unsupported CSI', function() {
+      it('(italic)', function() {
+        this.timeout(1);
+        var start = "foo\033[3mbar\033[0mbaz";
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql('foobarbaz');
+      });
+      it('(cursor-up)', function() {
+        this.timeout(1);
+        var start = "foo\033[1Abar";
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql('foobar');
+      });
+      it('(scroll-left)', function() {
+        this.timeout(1);
+        // <ESC>[1 @ (including ascii space)
+        var start = "foo\033[1 @bar";
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql('foobar');
+      });
+      it('(DECMC)', function() {
+        this.timeout(1);
+        var start = "foo\033[?11ibar";
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql('foobar');
+      });
+      it('(RLIMGCP)', function() {
+        this.timeout(1);
+        var start = "foo\033[<!3ibar";
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql('foobar');
+      });
+      it('(DECSCL)', function() {
+        this.timeout(1);
+        var start = "foo\033[61;0\"pbar"
+        var l = ansi_up.ansi_to_html(start);
+        l.should.eql('foobar');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Test Code:
```js
//                Unsupported CSI      Pure Text
//                vvvvvvvvv            vvvvvv
var txt = "ABC" + "\033[1@" + "FOO" + "[1;30m" + "BAD" + "\033[0m";
var html = ansi_up.ansi_to_html(txt);
console.log(html + "\n");
```
Current ansi_up Output:
```html
ABC<span style="color:rgb(85, 85, 85)">BAD</span>
```
PuTTY Display (for reference, printed same `txt` byte sequence by other program):
```
ABCFOO[1;30mBAD
```

----

In this test case, `[1;30m` is a pure text. It is not an escape sequence.

It caused by this regexp matching:
https://github.com/drudru/ansi_up/blob/8d120f8cd02ff6a83249dc0140c72c747454e322/ansi_up.js#L98

In this case, this string has been stored in the `text` variable: `[1@FOO[1;30mBAD`
This extraordinary string causes wrong matching and lost `"FOO"`.

If replace `text.match(/([\d;]*)m([\s\S]*)/m);` with `text.match(/^([\d;]*)m([\s\S]*)/m);`, this issue will assuage. (But it's not perfect, because unknown escape sequence still display)

Output If this change applied:
```
ABC1@FOO[1;30mBAD
```

Sorry my poor English. Thank you.