### PR TITLE
Improve performance of parsing large texts.

### DIFF
--- a/ansi_up.js
+++ b/ansi_up.js
@@ -56,21 +56,18 @@
     };
 
     Ansi_Up.prototype.ansi_to_html = function (txt, options) {
-
-      var data4 = txt.split(/\033\[/);
-
-      var first = data4.shift(); // the first chunk is not the result of the split
-
       var self = this;
-      var data5 = data4.map(function (chunk) {
+
+      var raw_text_chunks = txt.split(/\033\[/);
+      var first_chunk = raw_text_chunks.shift(); // the first chunk is not the result of the split
+
+      var color_chunks = raw_text_chunks.map(function (chunk) {
         return self.process_chunk(chunk, options);
       });
 
-      data5.unshift(first);
+      color_chunks.unshift(first_chunk);
 
-      var escaped_data = data5.join('');
-
-      return escaped_data;
+      return color_chunks.join('');
     };
 
     Ansi_Up.prototype.process_chunk = function (text, options) {

--- a/ansi_up.js
+++ b/ansi_up.js
@@ -68,15 +68,7 @@
 
       data5.unshift(first);
 
-      var flattened_data = data5.reduce( function (a, b) {
-        if (Array.isArray(b))
-          return a.concat(b);
-
-        a.push(b);
-        return a;
-      }, []);
-
-      var escaped_data = flattened_data.join('');
+      var escaped_data = data5.join('');
 
       return escaped_data;
     };
@@ -142,9 +134,9 @@
           }
         }
         if (use_classes) {
-          return ["<span class=\"" + classes.join(' ') + "\">", orig_txt, "</span>"];
+          return "<span class=\"" + classes.join(' ') + "\">" + orig_txt + "</span>";
         } else {
-          return ["<span style=\"" + styles.join(';') + "\">", orig_txt, "</span>"];
+          return "<span style=\"" + styles.join(';') + "\">"  + orig_txt + "</span>";
         }
       }
     };


### PR DESCRIPTION
The current implementation of `process_chunk` returns either a text or an array, which is then "flattened" out later, this is a slow process if the input string is large.

This commit makes the chunking method consistently return a string, which also does not need to be flattened out.