### PR TITLE
extended-color CSI (true color)

### DIFF
--- a/test/ansi_up-test.js
+++ b/test/ansi_up-test.js
@@ -274,6 +274,27 @@ describe('ansi_up', function() {
           l.should.eql(expected);
         });
       });
+
+      describe('transform extend colors (true color)', function() {
+        it('foreground', function() {
+          var start = "\033[38;2;42;142;242m" + "foo" + "\033[0m";
+          var expected = '<span style="color:rgb(42, 142, 242)">foo</span>';
+          var l = ansi_up.ansi_to_html(start);
+          l.should.eql(expected);
+        });
+        it('background', function() {
+          var start = "\033[48;2;42;142;242m" + "foo" + "\033[0m";
+          var expected = '<span style="background-color:rgb(42, 142, 242)">foo</span>';
+          var l = ansi_up.ansi_to_html(start);
+          l.should.eql(expected);
+        });
+        it('both foreground and background', function() {
+          var start = "\033[38;2;42;142;242;48;2;1;2;3m" + "foo" + "\033[0m";
+          var expected = '<span style="color:rgb(42, 142, 242);background-color:rgb(1, 2, 3)">foo</span>';
+          var l = ansi_up.ansi_to_html(start);
+          l.should.eql(expected);
+        });
+      });
     });
 
     describe('themed colors', function() {
@@ -388,6 +409,27 @@ describe('ansi_up', function() {
         it('combination of palette and bold', function() {
           var start = "\033[38;5;171;1m" + "foo" + "\033[0m";
           var expected = '<span class="ansi-palette-171-fg">foo</span>';
+          var l = ansi_up.ansi_to_html(start, {use_classes: true});
+          l.should.eql(expected);
+        });
+      });
+
+      describe('transform extend colors (true color)', function() {
+        it('foreground', function() {
+          var start = "\033[38;2;42;142;242m" + "foo" + "\033[0m";
+          var expected = '<span class="ansi-truecolor-fg" data-ansi-truecolor-fg="42, 142, 242">foo</span>';
+          var l = ansi_up.ansi_to_html(start, {use_classes: true});
+          l.should.eql(expected);
+        });
+        it('background', function() {
+          var start = "\033[48;2;42;142;242m" + "foo" + "\033[0m";
+          var expected = '<span class="ansi-truecolor-bg" data-ansi-truecolor-bg="42, 142, 242">foo</span>';
+          var l = ansi_up.ansi_to_html(start, {use_classes: true});
+          l.should.eql(expected);
+        });
+        it('both foreground and background', function() {
+          var start = "\033[38;2;42;142;242;48;2;1;2;3m" + "foo" + "\033[0m";
+          var expected = '<span class="ansi-truecolor-fg ansi-truecolor-bg" data-ansi-truecolor-fg="42, 142, 242" data-ansi-truecolor-bg="1, 2, 3">foo</span>';
           var l = ansi_up.ansi_to_html(start, {use_classes: true});
           l.should.eql(expected);
         });


### PR DESCRIPTION
refs #17 and its comment.

in NOT `use_classes` mode, works fine as expected.

in `use_classes` mode, HTML will generate like below:
```html
<span class="ansi-truecolor-fg" data-ansi-truecolor-fg="12, 34, 56">...</span>
```
users may process with this class and data-attribute in their JavaScript code.
or may ignore safely.

I think this behaviour needs to update README file, but not enough is my English ability to write the sentence. sorry.

Demo: https://wandbox.fetus.jp/permlink/nv0spVOYDAWYZPQx#result-container
(This is an output demonstration. I believe users will use this feature for respectable output.)