### PR TITLE
Add license to package.json and reformat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,33 +1,32 @@
 {
-	"name": "ansi_up",
-	"version": "1.3.0",
-	"description": "Convert ansi sequences in strings to colorful HTML",
-	"keywords": ["ansi", "html"],
-	"author": "drudru <drudru@gmail.com>",
-	"main": "./ansi_up.js",
-	"repository" :
-		{ 
-		  "type" : "git",
-		  "url" : "git://github.com/drudru/ansi_up.git"
-		},
-    "bugs" : 
-    	{ 
-	    	"url" : "http://github.com/drudru/ansi_up/issues" 
-    	},
-	"engines": 
-		{ 
-			"node": "*"
-		},
-	"scripts": 
-		{ 
-			"test": "make test",
-			"build": "make build"
-		},
-	"devDependencies":
-		{
-			"mocha": "*",
-			"should": "*",
-			"jshint": "*",
-			"jslint": "*"
-		}
+  "name": "ansi_up",
+  "version": "1.3.0",
+  "description": "Convert ansi sequences in strings to colorful HTML",
+  "license": "MIT",
+  "keywords": [
+    "ansi",
+    "html"
+  ],
+  "author": "drudru <drudru@gmail.com>",
+  "main": "./ansi_up.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/drudru/ansi_up.git"
+  },
+  "bugs": {
+    "url": "http://github.com/drudru/ansi_up/issues"
+  },
+  "engines": {
+    "node": "*"
+  },
+  "scripts": {
+    "test": "make test",
+    "build": "make build"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "should": "*",
+    "jshint": "*",
+    "jslint": "*"
+  }
 }


### PR DESCRIPTION
This module gets an "unknown" from
[license-checker](https://github.com/davglass/license-checker), even
though the README has an MIT license.

Add the license to the package.json.

The file was also inconsistently indented, so fix the formatting.
