### PR TITLE
Fix typings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ typescript:
 		./node_modules/.bin/tsc -p .
 		cat ./umd.header ./dist/ansi_up.js ./umd.footer > ansi_up.js
 		mv  ./dist/ansi_up.js ./dist/ansi_up.js.include
+		node ./scripts/fix-typings.js
 		
 test:
 		@NODE_ENV=test ./node_modules/.bin/mocha \

--- a/dist/ansi_up.d.ts
+++ b/dist/ansi_up.d.ts
@@ -1,19 +1,19 @@
-interface AU_Color {
+export interface AU_Color {
     rgb: number[];
     class_name: string;
 }
-interface TextWithData {
+export interface TextWithData {
     fg: AU_Color;
     bg: AU_Color;
     bright: boolean;
     text: string;
 }
-interface Formatter {
+export interface Formatter {
     transform(fragment: TextWithData, instance: AnsiUp): any;
     compose(segments: any[], instance: AnsiUp): any;
 }
 declare function rgx(tmplObj: any, ...subst: any[]): RegExp;
-declare class AnsiUp {
+export default class AnsiUp {
     VERSION: string;
     ansi_colors: {
         rgb: number[];

--- a/scripts/fix-typings.js
+++ b/scripts/fix-typings.js
@@ -1,0 +1,15 @@
+
+var fs = require('fs');
+var path = require('path');
+
+var HERE = __dirname;
+var typings = path.resolve(HERE, '..', 'dist', 'ansi_up.d.ts');
+
+var content = fs.readFileSync(typings, 'utf-8');
+
+var new_content = content.replace(/^interface /mg, 'export interface ');
+new_content = new_content.replace(/^declare class AnsiUp/mg, 'export default class AnsiUp');
+
+if (new_content !== content) {
+    fs.writeFileSync(typings, new_content, 'utf-8');
+}


### PR DESCRIPTION
After 576888768505510124ddbcd60e670d7f5b745e01, typings were broken. This adds a script that fixes the typings on build. A more robust solution would maybe be to revert 576888768505510124ddbcd60e670d7f5b745e01 and instead add a script that patches the output.