### PR TITLE
reversing the order of the SGR commands, so that a [36;1m applies the…

### DIFF
--- a/ansi_up.ts
+++ b/ansi_up.ts
@@ -549,7 +549,7 @@ class AnsiUp
     {
       // Ok - we have a valid "SGR" (Select Graphic Rendition)
 
-      let sgr_cmds = pkt.text.split(';');
+      let sgr_cmds = pkt.text.split(';').reverse();
 
       // Each of these params affects the SGR state
 


### PR DESCRIPTION
… bright to the 36.

otherwise, it drops some of the bright codes, because they don't end up applying to the base code they are set on. Because the 36 is processed first, as a normal, and the bright doesn't get applied to it.

If you reverse the order of the SGR commands, the bright get applied to it's base code. 

_note_ - I'm not sure about how exactly the script is processed, and if this is the proper place to make the change so that the raw .js file is generated correctly.  