### PR TITLE
Option for disabling escaping HTML reserved characters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -120,6 +120,11 @@ See the examples directory for a complete CSS theme for these classes.
 
 ## Properties
 
+#### escape_html
+(default: true)
+
+By default, HTML's reserved characters `& < > " '` are replaced with <a href="https://www.w3schools.com/html/html_entities.asp">HTML entities</a> to make them appear as literal characters in your application, rather than being interpreted as HTML structure. If you prefer keeping HTML's reserved characters untouched, you can set this to false.
+
 #### use_classes
 (default: false)
 

--- a/ansi_up.ts
+++ b/ansi_up.ts
@@ -188,6 +188,8 @@ class AnsiUp
 
     private escape_txt_for_html(txt:string):string
     {
+      if (!this._escape_html)
+          return txt;
       return txt.replace(/[&<>"']/gm, (str) => {
         if (str === "&")  return "&amp;";
         if (str === "<")  return "&lt;";
@@ -661,8 +663,7 @@ class AnsiUp
         if (txt.length === 0)
             return txt;
 
-        if (this._escape_html)
-            txt = this.escape_txt_for_html(txt);
+        txt = this.escape_txt_for_html(txt);
 
         // If colors not set, default style is used
         if (!fragment.bold && !fragment.italic && !fragment.underline && fragment.fg === null && fragment.bg === null)
@@ -730,8 +731,7 @@ class AnsiUp
         if (! this._url_whitelist[parts[0]])
             return '';
 
-        let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this._escape_html ? this.escape_txt_for_html(pkt.text) : pkt.text}</a>`;
-        // Escape href="" even if this._escape_html is false, to avoid breaking the <a> in case pkt.url contains a double quote.
+        let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this.escape_txt_for_html(pkt.text)}</a>`;
         
         return result;
     }

--- a/ansi_up.ts
+++ b/ansi_up.ts
@@ -76,6 +76,7 @@ class AnsiUp
     private _osc_regex:RegExp;
 
     private _url_whitelist:{};
+    private _escape_html:boolean;
 
     private _buffer:string;
 
@@ -93,6 +94,7 @@ class AnsiUp
         this._buffer = '';
 
         this._url_whitelist = { 'http':1, 'https':1 };
+        this._escape_html = true;
     }
 
     set use_classes(arg:boolean)
@@ -113,6 +115,16 @@ class AnsiUp
     get url_whitelist():{}
     {
         return this._url_whitelist;
+    }
+
+    set escape_html(arg:boolean)
+    {
+        this._escape_html = arg;
+    }
+
+    get escape_html():boolean
+    {
+        return this._escape_html;
     }
 
 
@@ -649,7 +661,8 @@ class AnsiUp
         if (txt.length === 0)
             return txt;
 
-        txt = this.escape_txt_for_html(txt);
+        if (this._escape_html)
+            txt = this.escape_txt_for_html(txt);
 
         // If colors not set, default style is used
         if (!fragment.bold && !fragment.italic && !fragment.underline && fragment.fg === null && fragment.bg === null)
@@ -717,7 +730,9 @@ class AnsiUp
         if (! this._url_whitelist[parts[0]])
             return '';
 
-        let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this.escape_txt_for_html(pkt.text)}</a>`;
+        let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this._escape_html ? this.escape_txt_for_html(pkt.text) : pkt.text}</a>`;
+        // Escape href="" even if this._escape_html is false, to avoid breaking the <a> in case pkt.url contains a double quote.
+        
         return result;
     }
 }

--- a/ansi_up.ts
+++ b/ansi_up.ts
@@ -732,7 +732,6 @@ class AnsiUp
             return '';
 
         let result = `<a href="${this.escape_txt_for_html(pkt.url)}">${this.escape_txt_for_html(pkt.text)}</a>`;
-        
         return result;
     }
 }


### PR DESCRIPTION
Hi,

I'd like to propose creating an option named `escape_html` that defaults to `true`, but can be turned off.

Background: I'm adopting this library for [_Shell commands_ plugin for Obsidian](https://github.com/Taitava/obsidian-shellcommands). [Obsidian.md](https://obsidian.md/) is a knowdge base/note taking application, and my plugin provides an ability to execute shell commands via hotkeys within Obsidian. One feature is that output received from shell commands can be utilized in Obsidian, for example by inserting the output to a currently open note.

As Obsidian uses the Markdown format for notes, it can display HTML content really well, so I'd like to combine being able to convert ANSI code to HTML, and also retain any possible HTML that might be outputted by user-specified shell commands.

Thank you for considering this! 🙂 This is just a proposal, and I'm willing to make changes if needed.

P.S. There are four commits in this PR, but they can be squashed to one. I was first thinking about making the `href=""` attribute **not** to be affected by this option for hyperlinks (i.e. it would always escape `href`` value even if the option is `false`). But I changed my mind, as I came to think about that `&` should not be escaped in urls as they might be part of a query string. So now setting `escape_html` to false prevents all escaping. I'm not 100% sure about this decision, so please let me know if you have any opinions. 🙂 