### PR TITLE
fix: Include faint style when no other modifiers are active

### DIFF
--- a/ansi_up.js
+++ b/ansi_up.js
@@ -359,7 +359,7 @@ export class AnsiUp {
         if (txt.length === 0)
             return txt;
         txt = this.escape_txt_for_html(txt);
-        if (!fragment.bold && !fragment.italic && !fragment.underline && fragment.fg === null && fragment.bg === null)
+        if (!fragment.bold && !fragment.faint && !fragment.italic && !fragment.underline && fragment.fg === null && fragment.bg === null)
             return txt;
         let styles = [];
         let classes = [];


### PR DESCRIPTION
Previously, faint text was ignored when no other modifiers were active (bold, italic, underline, colors). This PR fixes the fast-case check to output formatting if only faint is active.