### PR TITLE
Fix handling of faint-only style

### DIFF
--- a/ansi_up.ts
+++ b/ansi_up.ts
@@ -688,7 +688,7 @@ export class AnsiUp
         txt = this.escape_txt_for_html(txt);
 
         // If colors not set, default style is used
-        if (!fragment.bold && !fragment.italic && !fragment.underline && fragment.fg === null && fragment.bg === null)
+        if (!fragment.bold && !fragment.italic && !fragment.faint && !fragment.underline && fragment.fg === null && fragment.bg === null)
             return txt;
 
         let styles:string[] = [];


### PR DESCRIPTION
This is a fix of the PR done in #93. That PR seems to have updated the generated ansi_up.js file instead of ansi_up.ts, which caused the file to be overwritten when the version bump recompiled the files in 65baddb93b16e75cf5a33104501dd1cfa921f404. This PR performs the same change as #93, but in ansi_up.ts instead of ansi_up.js.